### PR TITLE
Fix missing icon in CheckableComboBox #28

### DIFF
--- a/dev_scripts/compile_ui_files.py
+++ b/dev_scripts/compile_ui_files.py
@@ -5,6 +5,5 @@ from pathlib import Path
 from qute_style.dev.dev_functions import compile_ui_files
 
 if __name__ == "__main__":
-    if Path.cwd().stem == "dev_scripts":
-        os.chdir(Path.cwd().parent)
+    os.chdir(Path(__file__).parent.parent)
     compile_ui_files([Path("qute_style") / "ui"])

--- a/examples/main.py
+++ b/examples/main.py
@@ -6,7 +6,17 @@ import logging
 import sys
 from pathlib import Path
 
-from PyQt5.QtCore import Qt
+from PyQt5.QtCore import (
+    QMessageLogContext,
+    Qt,
+    QtCriticalMsg,
+    QtDebugMsg,
+    QtFatalMsg,
+    QtInfoMsg,
+    QtMsgType,
+    QtWarningMsg,
+    qInstallMessageHandler,
+)
 from PyQt5.QtWidgets import QApplication
 
 from examples.sample_main_window import StyledMainWindow
@@ -29,6 +39,39 @@ def create_new_changelog_resource_file(app_name: str) -> None:
     importlib.import_module("examples.resources_cl")
 
 
+def configure_logging() -> None:
+    """Configure logging for the example app."""
+    format_str = (
+        "%(asctime)s.%(msecs)03d %(threadName)10s  - "
+        "%(name)-50s - %(funcName)-25s:%(lineno)-4s - "
+        "%(levelname)-8s - %(message)s"
+    )
+    date_format = "%Y-%m-%d %H:%M:%S"
+    formatter = logging.Formatter(format_str, date_format)
+
+    handler = logging.StreamHandler()
+    handler.setFormatter(formatter)
+
+    logger = logging.getLogger("qute_style")
+    logger.addHandler(handler)
+    logger.setLevel(logging.DEBUG)
+
+    def qt_message_handler(
+        mode: QtMsgType, _: QMessageLogContext, message: str
+    ) -> None:
+        """Handle messages from Qt logging."""
+        level = {
+            QtDebugMsg: logging.DEBUG,
+            QtInfoMsg: logging.INFO,
+            QtWarningMsg: logging.WARNING,
+            QtCriticalMsg: logging.ERROR,
+            QtFatalMsg: logging.FATAL,
+        }[mode]
+        log.log(level, message)
+
+    qInstallMessageHandler(qt_message_handler)
+
+
 class QuteStyleCustomApplication(QuteStyleApplication):
     """QuteStyleCustomApplication."""
 
@@ -45,11 +88,11 @@ class QuteStyleCustomApplication(QuteStyleApplication):
 
 
 if __name__ == "__main__":
-    APP_NAME = "Test-App"
+    configure_logging()
 
     # Create the resource file everytime the application starts.
     # No need to add it as a resource for the demo app
-    create_new_changelog_resource_file(APP_NAME)
+    create_new_changelog_resource_file("Test-App")
 
     # activate highdpi icons and scaling
     QApplication.setAttribute(Qt.AA_EnableHighDpiScaling)

--- a/examples/sample_widgets.py
+++ b/examples/sample_widgets.py
@@ -9,6 +9,7 @@ from PyQt5.QtCore import (
     QFileInfo,
     QModelIndex,
     QObject,
+    QSize,
     QStringListModel,
     Qt,
     pyqtSlot,
@@ -48,6 +49,12 @@ class TestWidget(MainWidget):
         super().__init__(parent)
         self._ui = Ui_test_widget()
         self._ui.setupUi(self)
+        heart_path = ":/svg_icons/heart_broken.svg"
+        icon = QIcon(CustomIconEngine(heart_path, "foreground"))
+        self._ui.custom_icon_engine_checkbox.setIcon(icon)
+        self._ui.custom_icon_engine_checkbox.setIconSize(QSize(16, 16))
+        self._ui.icon_checkbox.setIcon(QIcon(heart_path))
+        self._ui.icon_checkbox.setIconSize(QSize(16, 16))
         menu = QMenu(self._ui.pushButton_2)
         all_checkbox = QCheckBox(self.tr("Select everything"))
         widget_action = QWidgetAction(menu)
@@ -66,11 +73,7 @@ class TestWidget(MainWidget):
         self._ui.disable_widgets.clicked.connect(self.on_widgets_disabled)
         self._ui.transparent_combobox.setProperty("cssClass", "transparent")
         self._ui.pushButton_2.setMenu(menu)
-        self._ui.pushButton_2.setIcon(
-            QIcon(
-                CustomIconEngine(":/svg_icons/heart_broken.svg", "foreground")
-            )
-        )
+        self._ui.pushButton_2.setIcon(icon)
         self._ui.pushButton_4.set_icon(":/svg_icons/accept.svg")
         self._ui.splitter_button.setText("Change orientation")
         self._ui.splitter_button.clicked.connect(self.on_change_orientation)

--- a/qute_style/gen/ui_test_window.py
+++ b/qute_style/gen/ui_test_window.py
@@ -127,6 +127,14 @@ class Ui_test_widget(object):
         self.checkBox_5.setTristate(True)
         self.checkBox_5.setObjectName("checkBox_5")
         self.verticalLayout_5.addWidget(self.checkBox_5)
+        self.custom_icon_engine_checkbox = QtWidgets.QCheckBox(self.groupBox)
+        self.custom_icon_engine_checkbox.setObjectName(
+            "custom_icon_engine_checkbox"
+        )
+        self.verticalLayout_5.addWidget(self.custom_icon_engine_checkbox)
+        self.icon_checkbox = QtWidgets.QCheckBox(self.groupBox)
+        self.icon_checkbox.setObjectName("icon_checkbox")
+        self.verticalLayout_5.addWidget(self.icon_checkbox)
         self.horizontalLayout_5 = QtWidgets.QHBoxLayout()
         self.horizontalLayout_5.setObjectName("horizontalLayout_5")
         self.checkBox_3 = Toggle(self.groupBox)
@@ -327,6 +335,12 @@ class Ui_test_widget(object):
         self.radioButton_2.setText(_translate("test_widget", "RadioButton"))
         self.radioButton_3.setText(_translate("test_widget", "RadioButton"))
         self.checkBox_5.setText(_translate("test_widget", "CheckBox"))
+        self.custom_icon_engine_checkbox.setText(
+            _translate("test_widget", "Checkbox with CustomIconEngine")
+        )
+        self.icon_checkbox.setText(
+            _translate("test_widget", "CheckBox with QIcon")
+        )
         self.checkBox_3.setText(
             _translate(
                 "test_widget",

--- a/qute_style/ui/test_window.ui
+++ b/qute_style/ui/test_window.ui
@@ -250,6 +250,20 @@
          </widget>
         </item>
         <item>
+         <widget class="QCheckBox" name="custom_icon_engine_checkbox">
+          <property name="text">
+           <string>Checkbox with CustomIconEngine</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="icon_checkbox">
+          <property name="text">
+           <string>CheckBox with QIcon</string>
+          </property>
+         </widget>
+        </item>
+        <item>
          <layout class="QHBoxLayout" name="horizontalLayout_5">
           <item>
            <widget class="Toggle" name="checkBox_3">

--- a/qute_style/widgets/styled_combobox.py
+++ b/qute_style/widgets/styled_combobox.py
@@ -8,6 +8,7 @@ from PyQt5 import QtGui
 from PyQt5.QtCore import QEvent, QModelIndex, QObject, QPoint, Qt, pyqtSlot
 from PyQt5.QtGui import (
     QFontMetrics,
+    QIcon,
     QMouseEvent,
     QPainter,
     QResizeEvent,
@@ -23,7 +24,7 @@ from PyQt5.QtWidgets import (
 )
 
 from qute_style.style import get_color
-from qute_style.widgets.custom_icon_engine import PixmapStore
+from qute_style.widgets.custom_icon_engine import CustomIconEngine, PixmapStore
 
 log = logging.getLogger(f"tsl.{__name__}")  # pylint: disable=invalid-name
 
@@ -243,12 +244,20 @@ class CheckableComboBox(StyledComboBox, Generic[ItemData]):
         icon_color: str | None = None,
     ) -> None:
         """Add an Item to the Combobox."""
+        assert not (
+            icon_color and not icon_path
+        ), "Color can only be passed together with an icon (path)"
         item = QStandardItem(text)
         item.setData(data)
         item.setFlags(Qt.ItemIsEnabled | Qt.ItemIsUserCheckable)
         item.setData(Qt.Unchecked, Qt.CheckStateRole)
-        item.setData(icon_path, Qt.DecorationRole)
-        item.setData(icon_color, Qt.ForegroundRole)
+        if icon_path:
+            item.setData(
+                QIcon(CustomIconEngine(icon_path, "foreground")),
+                Qt.DecorationRole,
+            )
+            if icon_color:
+                item.setData(icon_color, Qt.ForegroundRole)
         cast(QStandardItemModel, self.model()).appendRow(item)
         self.update_text()
 

--- a/qute_style/widgets/styled_combobox.py
+++ b/qute_style/widgets/styled_combobox.py
@@ -244,9 +244,10 @@ class CheckableComboBox(StyledComboBox, Generic[ItemData]):
         icon_color: str | None = None,
     ) -> None:
         """Add an Item to the Combobox."""
-        assert not (
-            icon_color and not icon_path
-        ), "Color can only be passed together with an icon (path)"
+        if icon_color and not icon_path:
+            raise AssertionError(
+                "Color can only be passed together with an icon (path)"
+            )
         item = QStandardItem(text)
         item.setData(data)
         item.setFlags(Qt.ItemIsEnabled | Qt.ItemIsUserCheckable)

--- a/tests/test_checkbox.py
+++ b/tests/test_checkbox.py
@@ -1,4 +1,6 @@
 """Tests for StyledComboBox and CheckableComboBox."""
+from __future__ import annotations
+
 from random import randint
 from typing import List, cast
 
@@ -12,8 +14,10 @@ from qute_style.widgets.styled_combobox import (
     TooManyItemsError,
 )
 
-
 # pylint: disable=protected-access
+from tests.conftest import random_string
+
+
 @pytest.fixture(scope="function", name="cb_items")
 def fixture_cb_items(combobox: CheckableComboBox[int]) -> None:
     """Create several test items."""
@@ -33,6 +37,26 @@ def fixture_combobox(
     combobox.show()
     qtbot.waitUntil(combobox.isVisible)
     return combobox
+
+
+@pytest.mark.parametrize("icon", (None, "", "test.svg"))
+@pytest.mark.parametrize("color", ("foreground", None))
+def test_add_item(
+    combobox: CheckableComboBox[int], icon: str | None, color: str | None
+) -> None:
+    """Test that add_item creates a properly configured QStandardItem."""
+
+    def call():
+        combobox.addItem(random_string(), randint(0, 10), icon, color)
+
+    if color and not icon:
+        with pytest.raises(AssertionError):
+            call()
+    else:
+        call()
+        model = cast(QStandardItemModel, combobox.model())
+        item = model.item(model.rowCount() - 1, 0)
+        assert bool(item.data(Qt.DecorationRole)) is bool(icon)
 
 
 @pytest.mark.parametrize("mode", (False, True))


### PR DESCRIPTION
Fixes #28 

When setting the data on the `QStandardItem` for role `Qt.DecorationRole` we currently pass a path. Instead, we need to pass a `QIcon`.

Added console logging for debug purposes.

Updated example app.
